### PR TITLE
Fix partner key setup in tests and README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ php artisan vendor:publish --provider="Hofmannsven\Brevo\BrevoServiceProvider"
 
 ### Set the API Key
 
-In your `.env' file, add your Brevo API key:
+In your `.env` file, add your Brevo API key:
 
 ```
 BREVO_API_KEY=xxx

--- a/tests/LaravelBrevoTest.php
+++ b/tests/LaravelBrevoTest.php
@@ -41,7 +41,7 @@ final class LaravelBrevoTest extends Orchestra
     protected function getEnvironmentSetUp($app): void
     {
         $app['config']->set('brevo.api_key', 'my_api_key');
-        $app['config']->set('brevo.my_partner_key', 'my_partner_key');
+        $app['config']->set('brevo.partner_key', 'my_partner_key');
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix typo when setting `BREVO_PARTNER_KEY` in tests
- correct README typo around `.env` mention

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8214380483268585e9e51789ce6c