### PR TITLE
Fix CI: Exclude prefer-lowest for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,6 +30,8 @@ jobs:
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 11.*
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
Orchestra Testbench 9.x versions have progressively increased their minimum Laravel requirements (9.9.0+ requires Laravel 11.35.0, 9.17.0+ requires Laravel 11.45.3). This causes the prefer-lowest strategy to fail because it tries to install Laravel 11.0.3 with a testbench version that requires a higher Laravel version.

Since Laravel 11 is mature and testing against the absolute lowest version provides limited value, we exclude prefer-lowest testing for Laravel 11.*.

Fixes the failing "P8.3 - L11.* - prefer-lowest - ubuntu-latest" CI job.