### PR TITLE
Update PHPUnit version constraints to require minimum patch versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^7.0|^8.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "phpunit/phpunit": "^10.1|^11.0|^12.0"
+        "phpunit/phpunit": "^10.5.62|^11.5.50|^12.5.22"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
Updated PHPUnit dependency version constraints in `composer.json` to specify minimum patch versions for better stability and security.

## Changes
- Updated PHPUnit version constraint from `^10.1|^11.0|^12.0` to `^10.5.62|^11.5.50|^12.5.22`
- This ensures that projects using this package will install PHPUnit versions with important bug fixes and security patches included

## Details
The constraint now requires:
- PHPUnit 10.x: minimum version 10.5.62
- PHPUnit 11.x: minimum version 11.5.50
- PHPUnit 12.x: minimum version 12.5.22

This change improves the reliability of the testing environment by preventing installation of older patch versions that may contain known issues.